### PR TITLE
Add a .gitattributes file to improve language stats

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+tutorials/* linguist-documentation
+examples/* linguist-documentation
+docs/* linguist-documentation


### PR DESCRIPTION
This tells GitHub that the docs and tutorials shouldn't be counted towards the language stats. Feel free to ignore, but I enjoyed this when I learned about it.

Reference: https://github.com/github/linguist#using-gitattributes