### PR TITLE
Add round to int casting

### DIFF
--- a/pyGPGO/GPGO.py
+++ b/pyGPGO/GPGO.py
@@ -171,7 +171,7 @@ class GPGO:
         res_d = OrderedDict()
         for i, (key, param_type) in enumerate(zip(self.parameter_key, self.parameter_type)):
             if param_type == 'int':
-                res_d[key] = int(opt_x[i])
+                res_d[key] = int(round(opt_x[i]))
             else:
                 res_d[key] = opt_x[i]
         return res_d, self.tau


### PR DESCRIPTION
The existing logic to cast hyperparameters to int doesn't round, thus all hyperparams will be implicitly floored.